### PR TITLE
[MM#6] Add Categories for Transactions

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -77,6 +77,7 @@ class TransactionsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def transaction_params
-    params.require(:transaction).permit(:date, :description, :amount, :transaction_type, :company_id)
+    params.require(:transaction).permit(:date, :description, :amount, :transaction_type, :company_id,
+                                        :categorizable)
   end
 end

--- a/app/helpers/transaction_helper.rb
+++ b/app/helpers/transaction_helper.rb
@@ -6,4 +6,18 @@ module TransactionHelper
       [type.titleize, type]
     end
   end
+
+  def categorizable_options
+    # categories = Category.all.concat current_company.categories.to_a # THIS WILL BE THE EVENTUAL CHANGES
+    categories = Category.all
+    categories.map do |category|
+      [category.name, category.to_signed_global_id]
+    end
+  end
+
+  def selected_categorizable_option(transaction, options)
+    options.find do |option|
+      option.last == transaction.categorizable&.to_signed_global_id
+    end
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Category < ApplicationRecord
+  has_many :subcategories, dependent: :destroy
+  has_many :transactions, as: :categorizable, dependent: :destroy
+end

--- a/app/models/subcategory.rb
+++ b/app/models/subcategory.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Subcategory < ApplicationRecord
+  belongs_to :category
+  has_many :transactions, as: :categorizable, dependent: :destroy
+end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -2,10 +2,21 @@
 
 class Transaction < ApplicationRecord
   belongs_to :company
+  belongs_to :categorizable, polymorphic: true, optional: true
 
   enum :transaction_type, { income: 'income', expense: 'expense' }, validate: true
 
   monetize :amount_cents, numericality: { greater_than: 0 }
 
   validates :date, :amount_cents, :transaction_type, presence: true
+
+  validate :categorizable_presence_for_expense
+
+  private
+
+  def categorizable_presence_for_expense
+    return unless expense? && categorizable.nil?
+
+    errors.add(:categorizable, 'must be present for expense transactions')
+  end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -12,6 +12,14 @@ class Transaction < ApplicationRecord
 
   validate :categorizable_presence_for_expense
 
+  def categorizable=(categorizable)
+    if categorizable.is_a?(String) # Check if it is a signed global id
+      super(GlobalID::Locator.locate_signed(categorizable))
+    else
+      super
+    end
+  end
+
   private
 
   def categorizable_presence_for_expense

--- a/app/views/transactions/_form.html.slim
+++ b/app/views/transactions/_form.html.slim
@@ -6,6 +6,10 @@
   = f.input :date, as: :string, input_html: { data: { controller: 'date-input' } }
   = f.input :description, required: false
   = f.input :transaction_type, collection: transaction_type_options, selected: f.object.transaction_type || transaction_type_options.first
+
+  - options_for_categorizable = categorizable_options
+  = f.input :categorizable, label: 'Category', collection: options_for_categorizable, selected: selected_categorizable_option(f.object, options_for_categorizable), include_blank: true
+
   = f.input :amount, required: true, input_html: { value: f.object.amount || 0, data: { controller: 'money-input' } }
 
 - if show_delete_button

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -7,6 +7,7 @@ table.table
     tr
       th Date
       th Type
+      th Category
       th Description
       th Amount
       th
@@ -15,6 +16,7 @@ table.table
       tr
         td = transaction.date
         td = transaction.transaction_type.titleize
+        td = transaction.categorizable&.name
         td = transaction.description
         td = number_to_currency(transaction.amount)
         td = link_to 'View', edit_transaction_path(transaction)

--- a/db/migrate/20250118205336_create_categories.rb
+++ b/db/migrate/20250118205336_create_categories.rb
@@ -1,0 +1,8 @@
+class CreateCategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250118205437_create_subcategories.rb
+++ b/db/migrate/20250118205437_create_subcategories.rb
@@ -1,0 +1,9 @@
+class CreateSubcategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :subcategories do |t|
+      t.references :category, null: false, foreign_key: true
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250118205534_add_categorizable_to_transactions.rb
+++ b/db/migrate/20250118205534_add_categorizable_to_transactions.rb
@@ -1,0 +1,5 @@
+class AddCategorizableToTransactions < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :transactions, :categorizable, polymorphic: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_11_225037) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_18_205534) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "companies", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "subcategories", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_subcategories_on_category_id"
   end
 
   create_table "transactions", force: :cascade do |t|
@@ -28,6 +42,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_11_225037) do
     t.decimal "amount_cents", null: false
     t.string "transaction_type", null: false
     t.bigint "company_id", null: false
+    t.string "categorizable_type"
+    t.bigint "categorizable_id"
+    t.index ["categorizable_type", "categorizable_id"], name: "index_transactions_on_categorizable"
     t.index ["company_id"], name: "index_transactions_on_company_id"
   end
 
@@ -56,6 +73,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_11_225037) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "subcategories", "categories"
   add_foreign_key "transactions", "companies"
   add_foreign_key "user_companies", "companies"
   add_foreign_key "user_companies", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,32 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+require 'factory_bot_rails'
+
+# Including FactoryBot methods
+include FactoryBot::Syntax::Methods
+
+if Category.any?
+  puts "Categories already exist. Skipping seeding..."
+  return
+end
+
+# Seed Categories and Subcategories
+puts "Seeding Categories and Subcategories..."
+
+create(:category, name: 'Advertising')
+create(:category, name: 'Car and truck expenses')
+create(:category, name: 'Commissions and fees, contract labor')
+create(:category, name: 'Depletion')
+create(:category, name: 'Depreciation and section 179 expense deduction')
+create(:category, name: 'Employee benefit programs')
+create(:category, name: 'Insurance, interest')
+create(:category, name: 'Legal and professional services')
+create(:category, name: 'Office expense')
+create(:category, name: 'Pension and profit-sharing plans')
+create(:category, name: 'Rent or lease')
+create(:category, name: 'Repairs and maintenance')
+create(:category, name: 'Supplies')
+create(:category, name: 'Taxes and licenses')
+create(:category, name: 'Travel and meals')
+create(:category, name: 'Utilities')
+create(:category, name: 'Wages')
+
+puts "Seeding completed!"

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "Category ##{n}" }
+
+    trait :has_subcategory do
+      after(:create) do |category|
+        create(:subcategory, category:)
+      end
+    end
+  end
+end

--- a/spec/factories/subcategories.rb
+++ b/spec/factories/subcategories.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subcategory do
+    sequence(:name) { |n| "Subcategory ##{n}" }
+    category
+  end
+end

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     end
 
     trait :expense do
+      categorizable factory: %i[category]
       transaction_type { 'expense' }
     end
   end

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     end
 
     trait :expense do
-      categorizable factory: %i[category]
+      categorizable factory: :category
       transaction_type { 'expense' }
     end
   end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe Transaction do
 
   describe 'associations' do
     it { should belong_to(:company) }
+
+    context 'when the transaction is an expense' do
+      it 'belongs to a categorizable' do
+        transaction = build(:transaction, :expense, categorizable: nil)
+
+        expect(transaction).not_to be_valid
+        expect(transaction.errors[:categorizable]).to include('must be present for expense transactions')
+      end
+    end
+
+    context 'when the transaction is an income' do
+      it 'does not belong to a categorizable' do
+        transaction = create(:transaction, :income)
+
+        expect(transaction).to be_valid
+      end
+    end
   end
 
   describe 'scopes' do

--- a/spec/system/transactions_spec.rb
+++ b/spec/system/transactions_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Transactions' do
   let(:user) { create(:user, current_company: company) }
   let(:company) { create(:company) }
+  let!(:category) { create(:category) }
+  let!(:transaction) { create(:transaction, :expense, company:) }
 
   before do
     login_as user
@@ -13,16 +15,38 @@ RSpec.describe 'Transactions' do
     click_on 'Transactions'
   end
 
+  it 'can be viewed' do
+    expect(page).to have_content('Transactions')
+
+    expect(page).to have_content transaction.date
+    expect(page).to have_content transaction.description
+    expect(page).to have_content transaction.transaction_type.titleize
+    expect(page).to have_content transaction.categorizable&.name
+    expect(page).to have_content transaction.amount.format
+  end
+
   context 'when being created' do
     before do
       click_on 'New Transaction'
     end
 
-    it 'can be created' do
+    it 'can be created as an income without a category' do
       fill_in 'Date', with: '2021-01-01'
       fill_in 'Description', with: 'My New Transaction'
       select 'Income', from: 'Transaction type'
       fill_in 'Amount', with: '100'
+      click_on 'Create Transaction'
+
+      expect(page).to have_content('Transaction was successfully created')
+      expect(page).to have_content('My New Transaction')
+    end
+
+    it 'can be created as an expense with a category' do
+      fill_in 'Date', with: '2021-01-01'
+      fill_in 'Description', with: 'My New Transaction'
+      select 'Expense', from: 'Transaction type'
+      fill_in 'Amount', with: '100'
+      select category.name, from: 'Category'
       click_on 'Create Transaction'
 
       expect(page).to have_content('Transaction was successfully created')
@@ -46,15 +70,13 @@ RSpec.describe 'Transactions' do
 
     it 'can be edited' do
       fill_in 'Description', with: 'My Updated Transaction'
-      select 'Expense', from: 'Transaction type'
       find_field('Amount').send_keys(%i[command backspace]) # Clear the value in place
       fill_in 'Amount', with: '50.00'
       click_on 'Update Transaction'
 
       expect(page).to have_content('Transaction was successfully updated')
-      expect(transaction.reload.description).to eql 'My Updated Transaction'
-      expect(transaction.transaction_type).to eql 'expense'
-      expect(transaction.amount).to eq Money.new(5000, 'USD') # 50.00 USD
+      expect(page).to have_content('My Updated Transaction')
+      expect(transaction.reload.amount).to eq Money.new(5000, 'USD') # 50.00 USD
     end
 
     it 'can be deleted' do


### PR DESCRIPTION
## Why?

The transactions needed to have categories for sorting and tax categorization purposes.

## What Changed

Currently there is seed data for top level categories. The ability to create subcategories has been opened but not fleshed out yet.

* [x] Create association between categories, subcategories, and transaction
* [x] Create seed data for the categories
* [x] Add Category selection to the transaction workflow
* [x] Introduce the structure to create/assign subcategories in the future

## Health Checks

These can be done by entering `rake` in the terminal

* [x] parallel_rspec
* [x] rubocop
* [x] audit

## Screenshots

<img width="1020" alt="Screenshot 2025-01-19 at 12 39 37 PM" src="https://github.com/user-attachments/assets/7865ccc7-eaf7-4c6b-813f-0ffc52a987bd" />
<img width="1041" alt="Screenshot 2025-01-19 at 12 39 28 PM" src="https://github.com/user-attachments/assets/24761c8e-a000-4689-af86-3101cae39a5f" />
<img width="1027" alt="Screenshot 2025-01-19 at 12 39 22 PM" src="https://github.com/user-attachments/assets/1a216a25-68ca-402e-9d60-363a5ea9bf55" />
