### PR TITLE
[MM#11] Cleanup Transactions

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,0 @@
-//= link_tree ../images
-//= link application.js
-//= link_directory ../javascripts .js
-//= link application.css
-//= link_directory ../stylesheets .scss

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,3 +22,6 @@
 // Vendors
 @import 'vendors/shoelace/sl-menu-item.scss';
 @import 'vendors/shoelace/tokens.scss';
+
+// Utilities
+@import 'utilities/hidden.scss';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@
 
 // optics overrides
 @import 'components/optics-overrides/card.scss';
+@import 'components/optics-overrides/form.scss';
 @import 'components/optics-overrides/layout.scss';
 @import 'components/optics-overrides/navbar.scss';
 @import 'components/optics-overrides/table.scss';

--- a/app/assets/stylesheets/components/optics-overrides/form.scss
+++ b/app/assets/stylesheets/components/optics-overrides/form.scss
@@ -1,0 +1,7 @@
+.form-row {
+  --minimum-item-width: calc(var(--op-size-unit) * 50); // 200px
+
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--minimum-item-width), 1fr));
+  gap: var(--op-space-medium);
+}

--- a/app/assets/stylesheets/components/optics-overrides/layout.scss
+++ b/app/assets/stylesheets/components/optics-overrides/layout.scss
@@ -2,10 +2,6 @@
   padding-block: var(--op-space-3x-large);
 }
 
-.navbar__content {
-  .navbar__content__links {
-    display: flex;
-    align-self: flex-end;
-    gap: var(--op-space-3x-small);
-  }
+.navbar__content--centered {
+  justify-self: center;
 }

--- a/app/assets/stylesheets/components/optics-overrides/table.scss
+++ b/app/assets/stylesheets/components/optics-overrides/table.scss
@@ -1,4 +1,15 @@
 %table-global {
+  &.table--transactions {
+    .table--transactions__type,
+    .table--transactions__date {
+      width: calc(30 * var(--op-size-unit)); // 100px
+    }
+
+    .table--transactions__actions {
+      width: calc(18.75 * var(--op-size-unit)); // 75px
+    }
+  }
+
   .table__actions {
     display: flex;
     justify-content: end;

--- a/app/assets/stylesheets/utilities/hidden.scss
+++ b/app/assets/stylesheets/utilities/hidden.scss
@@ -1,0 +1,3 @@
+.hidden {
+  display: none;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,12 +8,9 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   helper_method :current_company
+  delegate :current_company, to: :current_user
 
   private
-
-  def current_company
-    current_user&.current_company
-  end
 
   def user_not_authorized
     redirect_to(request.referer || root_path, alert: 'You are not authorized to perform this action.')

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CompaniesController < ApplicationController
-  before_action :set_company, only: %i[edit update destroy]
+  before_action :set_company, only: %i[edit update destroy set_current]
   def index
     authorize Company
     @companies = current_user.companies
@@ -13,7 +13,6 @@ class CompaniesController < ApplicationController
   end
 
   def edit
-    @company = Company.find(params[:id])
     authorize @company
   end
 
@@ -36,7 +35,6 @@ class CompaniesController < ApplicationController
   end
 
   def update
-    @company = Company.find(params[:id])
     authorize @company
 
     if @company.update(company_params)
@@ -51,7 +49,6 @@ class CompaniesController < ApplicationController
   end
 
   def destroy
-    @company = Company.find(params[:id])
     authorize @company
 
     @company.destroy
@@ -64,11 +61,10 @@ class CompaniesController < ApplicationController
   end
 
   def set_current
-    company = Company.find(params[:id])
-    authorize company
+    authorize @company
 
-    if current_user.switch_current_company(company)
-      redirect_to root_path, notice: "Current company set to #{company.name}"
+    if current_user.switch_current_company(@company)
+      redirect_to root_path, notice: "Current company set to #{@company.name}"
     else
       redirect_to companies_path, alert: 'Could not set current company'
     end

--- a/app/controllers/subcategories_controller.rb
+++ b/app/controllers/subcategories_controller.rb
@@ -17,7 +17,6 @@ class SubcategoriesController < ApplicationController
 
   # GET /subcategories/1/edit
   def edit
-    @subcategory = Subcategory.find(params[:id])
     authorize @subcategory
   end
 
@@ -44,7 +43,6 @@ class SubcategoriesController < ApplicationController
 
   # PATCH/PUT /subcategories/1 or /subcategories/1.json
   def update
-    @subcategory = Subcategory.find(params[:id])
     authorize @subcategory
 
     if @subcategory.update(subcategory_params)
@@ -65,7 +63,6 @@ class SubcategoriesController < ApplicationController
 
   # DELETE /subcategories/1 or /subcategories/1.json
   def destroy
-    @subcategory = Subcategory.find(params[:id])
     authorize @subcategory
 
     @subcategory.destroy

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -7,9 +7,9 @@ class TransactionsController < ApplicationController
   def index
     authorize Transaction
 
-    @transactions = Transaction.where(company_id: current_company.id)
-    @total_income = @transactions.where(transaction_type: 'income').sum(:amount_cents) / 100
-    @total_expense = @transactions.where(transaction_type: 'expense').sum(:amount_cents) / 100
+    @transactions = current_company.transactions.order(date: :desc)
+    @total_income = @transactions.income.sum(:amount_cents) / 100
+    @total_expense = @transactions.expense.sum(:amount_cents) / 100
   end
 
   # GET /transactions/new
@@ -20,7 +20,6 @@ class TransactionsController < ApplicationController
 
   # GET /transactions/1/edit
   def edit
-    @transaction = Transaction.find(params[:id])
     authorize @transaction
   end
 
@@ -47,7 +46,6 @@ class TransactionsController < ApplicationController
 
   # PATCH/PUT /transactions/1 or /transactions/1.json
   def update
-    @transaction = Transaction.find(params[:id])
     authorize @transaction
 
     if @transaction.update(transaction_params)
@@ -68,7 +66,6 @@ class TransactionsController < ApplicationController
 
   # DELETE /transactions/1 or /transactions/1.json
   def destroy
-    @transaction = Transaction.find(params[:id])
     authorize @transaction
 
     @transaction.destroy

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,6 +12,7 @@ registerIconLibrary('system', {resolver: (_name) => ''}) // No Icons needed for 
 import '@shoelace-style/shoelace/dist/components/dropdown/dropdown' // Dropdown component
 import '@shoelace-style/shoelace/dist/components/menu/menu' // Menu component
 import '@shoelace-style/shoelace/dist/components/menu-item/menu-item' // Menu-item component
+import '@shoelace-style/shoelace/dist/components/divider/divider' // Menu-item component
 
 // Theme switching
 if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {

--- a/app/javascript/controllers/conditional_input_controller.js
+++ b/app/javascript/controllers/conditional_input_controller.js
@@ -2,19 +2,20 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="conditional-input"
 export default class extends Controller {
-  static targets = ["trigger", "conditionalInput"]
+  static targets = ["trigger", "conditionalInputWrapper", "conditionalInput"]
   static values = { condition: String }
 
   connect() {
-    this.conditionalInputTarget.classList.add("hidden")
+    this.checkCondition()
     this.triggerTarget.addEventListener("change", this.checkCondition.bind(this))
   }
 
   checkCondition() {
     if (this.triggerTarget.value === this.conditionValue) {
-      this.conditionalInputTarget.classList.remove("hidden")
+      this.conditionalInputWrapperTarget.classList.remove("hidden")
     } else {
-      this.conditionalInputTarget.classList.add("hidden")
+      this.conditionalInputWrapperTarget.classList.add("hidden")
+      this.conditionalInputTarget.value = ""
     }
   }
 }

--- a/app/javascript/controllers/conditional_input_controller.js
+++ b/app/javascript/controllers/conditional_input_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="conditional-input"
+export default class extends Controller {
+  static targets = ["trigger", "conditionalInput"]
+  static values = { condition: String }
+
+  connect() {
+    this.conditionalInputTarget.classList.add("hidden")
+    this.triggerTarget.addEventListener("change", this.checkCondition.bind(this))
+  }
+
+  checkCondition() {
+    if (this.triggerTarget.value === this.conditionValue) {
+      this.conditionalInputTarget.classList.remove("hidden")
+    } else {
+      this.conditionalInputTarget.classList.add("hidden")
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import ConditionalInputController from "./conditional_input_controller"
+application.register("conditional-input", ConditionalInputController)
+
 import DateInputController from "./date_input_controller"
 application.register("date-input", DateInputController)
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -10,7 +10,7 @@ class Transaction < ApplicationRecord
 
   validates :date, :amount_cents, :transaction_type, presence: true
 
-  validates :categorizable, presence: false, if: -> { income? }
+  validates :categorizable, absence: { message: 'cannot be present for income transactions' }, if: -> { income? }
   validates :categorizable, presence: { message: 'must be present for expense transactions' }, if: -> { expense? }
 
   def categorizable=(categorizable)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -10,7 +10,8 @@ class Transaction < ApplicationRecord
 
   validates :date, :amount_cents, :transaction_type, presence: true
 
-  validate :categorizable_presence_for_expense
+  validates :categorizable, presence: false, if: -> { income? }
+  validates :categorizable, presence: { message: 'must be present for expense transactions' }, if: -> { expense? }
 
   def categorizable=(categorizable)
     if categorizable.is_a?(String) # Check if it is a signed global id
@@ -22,13 +23,5 @@ class Transaction < ApplicationRecord
 
   def categorizable_name
     categorizable&.name
-  end
-
-  private
-
-  def categorizable_presence_for_expense
-    return unless expense? && categorizable.nil?
-
-    errors.add(:categorizable, 'must be present for expense transactions')
   end
 end

--- a/app/views/companies/edit.html.slim
+++ b/app/views/companies/edit.html.slim
@@ -1,6 +1,6 @@
 .page-header
   h1 Edit #{@company.name}
-  = link_to companies_path, class: 'btn btn' do
+  = link_to companies_path, class: 'btn' do
     = material_icon 'arrow_back'
     | Back
 

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -25,6 +25,6 @@
 
   = button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: "btn btn-destructive"
 
-  = link_to :back do
+  = link_to :back, class: 'btn' do
     = material_icon 'arrow_back'
     | Back

--- a/app/views/layouts/devise.html.slim
+++ b/app/views/layouts/devise.html.slim
@@ -13,7 +13,6 @@ html.sl-theme-light
   body.app-body
     = turbo_frame_tag 'modal'
     = turbo_frame_tag 'panel'
-    = render 'shared/header'
 
     .app__content
       = render "layouts/flash"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -4,7 +4,7 @@
       = image_tag 'logo.png', alt: 'Logo'
       | My Money
 
-    .navbar__content.navbar__content--justify-center
+    .navbar__content.navbar__content--justify-end
       - if current_company
         = current_company.name
       - else
@@ -28,3 +28,6 @@
 
           = link_to edit_user_registration_path do
             sl-menu-item Settings
+
+          = button_to destroy_user_session_path, method: :delete, class: 'full-width text-left' do
+            sl-menu-item Logout

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -11,18 +11,20 @@
         = link_to 'Create Your Company', new_company_path, class: 'btn-primary'
 
     .navbar__content
-      .navbar__content__links
-        - if current_company
-          = link_to 'Transactions', transactions_path, class: 'btn btn--small'
-          = link_to 'Subcategories', subcategories_path, class: 'btn btn--small'
-
       sl-dropdown placement='bottom-end'
         button.btn type='button' slot="trigger"
           = material_icon 'account_circle'
         sl-menu
-          = link_to edit_user_registration_path do
-            sl-menu-item Settings
+          - if current_company
+            = link_to transactions_path do
+              sl-menu-item Transactions
+            = link_to subcategories_path do
+              sl-menu-item Subcategories
 
           = link_to companies_path do
             sl-menu-item Companies
 
+          sl-divider
+
+          = link_to edit_user_registration_path do
+            sl-menu-item Settings

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -8,8 +8,7 @@
       - if current_company
         = current_company.name
       - else
-        = link_to new_company_path do
-          | Create Your Company
+        = link_to 'Create Your Company', new_company_path, class: 'btn-primary'
 
     .navbar__content
       .navbar__content__links

--- a/app/views/transactions/_form.html.slim
+++ b/app/views/transactions/_form.html.slim
@@ -3,17 +3,18 @@
 = simple_form_for @transaction do |f|
   = f.hidden_field :company_id, value: current_company.id
 
-  = f.input :date, as: :string, input_html: { data: { controller: 'date-input' } }
-  = f.input :description
-  = f.input :transaction_type, collection: transaction_type_options, include_black: false
+  .form-row
+    = f.input :date, as: :string, input_html: { data: { controller: 'date-input' } }
+    = f.input :amount, required: true, input_html: { value: f.object.amount || 0, data: { controller: 'money-input' } }
+    = f.input :transaction_type, collection: transaction_type_options, include_black: false
 
   - options_for_categorizable = categorizable_options
   = f.input :categorizable, label: 'Category', collection: options_for_categorizable, selected: selected_categorizable_option(f.object, options_for_categorizable), include_blank: true
+  = f.input :description
 
-  = f.input :amount, required: true, input_html: { value: f.object.amount || 0, data: { controller: 'money-input' } }
+.flex.justify-between
+  - if show_delete_button && policy(@transaction).destroy?
+    = button_to 'Delete Transaction', transaction_path(@transaction), method: :delete, data: { turbo_confirm: 'Are you sure?' }, class: 'btn btn-destructive'
 
-- if show_delete_button && policy(@transaction).destroy?
-  = button_to 'Delete Transaction', transaction_path(@transaction), method: :delete, data: { turbo_confirm: 'Are you sure?' }, class: 'btn btn-destructive'
-
-- submit_text = action_name === 'new'|| action_name === 'create' ? 'Create Transaction' : 'Update Transaction'
-= submit_button @transaction, submit_text, class: 'btn btn-primary'
+  - submit_text = action_name === 'new'|| action_name === 'create' ? 'Create Transaction' : 'Update Transaction'
+  = submit_button @transaction, submit_text, class: 'btn btn-primary'

--- a/app/views/transactions/_form.html.slim
+++ b/app/views/transactions/_form.html.slim
@@ -10,7 +10,9 @@
       = f.input :transaction_type, collection: transaction_type_options, include_blank: false, input_html: { data: { conditional_input_target: 'trigger' } }
 
     - options_for_categorizable = categorizable_options
-    = f.input :categorizable, label: 'Category', collection: options_for_categorizable, selected: selected_categorizable_option(f.object, options_for_categorizable), include_blank: true, wrapper_html: { data: { conditional_input_target: 'conditionalInput' } }
+    = f.input :categorizable, label: 'Category', collection: options_for_categorizable, selected: selected_categorizable_option(f.object, options_for_categorizable), include_blank: true,
+        wrapper_html: { data: { conditional_input_target: 'conditionalInputWrapper' } },
+        input_html: { data: {conditional_input_target: 'conditionalInput' } }
     = f.input :description
 
 .flex.justify-between

--- a/app/views/transactions/_form.html.slim
+++ b/app/views/transactions/_form.html.slim
@@ -1,16 +1,17 @@
 -# locals: (show_delete_button: false)
 
 = simple_form_for @transaction do |f|
-  = f.hidden_field :company_id, value: current_company.id
+  div data-controller='conditional-input' data-conditional-input-condition-value='expense'
+    = f.hidden_field :company_id, value: current_company.id
 
-  .form-row
-    = f.input :date, as: :string, input_html: { data: { controller: 'date-input' } }
-    = f.input :amount, required: true, input_html: { value: f.object.amount || 0, data: { controller: 'money-input' } }
-    = f.input :transaction_type, collection: transaction_type_options, include_black: false
+    .form-row
+      = f.input :date, as: :string, input_html: { data: { controller: 'date-input' } }
+      = f.input :amount, required: true, input_html: { value: f.object.amount || 0, data: { controller: 'money-input' } }
+      = f.input :transaction_type, collection: transaction_type_options, include_blank: false, input_html: { data: { conditional_input_target: 'trigger' } }
 
-  - options_for_categorizable = categorizable_options
-  = f.input :categorizable, label: 'Category', collection: options_for_categorizable, selected: selected_categorizable_option(f.object, options_for_categorizable), include_blank: true
-  = f.input :description
+    - options_for_categorizable = categorizable_options
+    = f.input :categorizable, label: 'Category', collection: options_for_categorizable, selected: selected_categorizable_option(f.object, options_for_categorizable), include_blank: true, wrapper_html: { data: { conditional_input_target: 'conditionalInput' } }
+    = f.input :description
 
 .flex.justify-between
   - if show_delete_button && policy(@transaction).destroy?

--- a/app/views/transactions/edit.html.slim
+++ b/app/views/transactions/edit.html.slim
@@ -1,4 +1,7 @@
-= link_to transactions_path, class: 'btn' do
+.page-header
+  h1 Update Transaction
+  = link_to transactions_path, class: 'btn' do
     = material_icon 'arrow_back'
     | Back
+
 = render 'form', show_delete_button: true

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -3,15 +3,15 @@
   - if policy(Transaction).new?
     = link_to 'New Transaction', new_transaction_path, class: 'btn'
 
-table.table
+table.table-primary.table--comfortable-density.table--transactions
   thead
     tr
-      th Date
-      th Type
+      th.table--transactions__date Date
+      th.table--transactions__type Type
       th Category
       th Description
       th Amount
-      th
+      th.table--transactions__actions
   tbody
     - @transactions.each do |transaction|
       tr
@@ -21,12 +21,10 @@ table.table
         td = transaction.description
         td = number_to_currency(transaction.amount)
         - if policy(transaction).edit?
-          td
-            .table__actions
-              = link_to 'View', edit_transaction_path(transaction), class: 'btn btn--small'
+          td = link_to 'View', edit_transaction_path(transaction), class: 'btn btn--small'
   tfoot
     tr
-      td colspan="3"
+      td colspan="2"
       td
         | Total Income
         br
@@ -35,7 +33,7 @@ table.table
         | Total Expense
         br
         = number_to_currency(@total_expense)
-      td
+      td colspan="2"
         | Total Balance
         br
         = number_to_currency(@total_income - @total_expense)

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -42,9 +42,10 @@ RSpec.describe Transaction do
 
     context 'when the transaction is an income' do
       it 'does not belong to a categorizable' do
-        transaction = create(:transaction, :income)
+        transaction = build(:transaction, :income, categorizable: create(:category))
 
-        expect(transaction).to be_valid
+        expect(transaction).not_to be_valid
+        expect(transaction.errors[:categorizable]).to include('cannot be present for income transactions')
       end
     end
   end

--- a/spec/system/subcategories_spec.rb
+++ b/spec/system/subcategories_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'Subcategories' do
     let!(:category2) { create(:category) }
 
     before do
+      click_on 'account_circle'
       click_on 'Subcategories'
 
       click_on 'View'

--- a/spec/system/transactions_spec.rb
+++ b/spec/system/transactions_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Transactions' do
     let!(:income_transaction2) { create(:transaction, company:, amount: '250.00') }
 
     before do
+      click_on 'account_circle'
       click_on 'Transactions'
     end
 
@@ -58,15 +59,16 @@ RSpec.describe 'Transactions' do
     let!(:subcategory) { create(:subcategory, category:, company:) }
 
     before do
+      click_on 'account_circle'
       click_on 'Transactions'
       click_on 'New Transaction'
     end
 
-    it 'can be created as an income without a category' do
+    it 'can be created as an income without a category', :js do
       fill_in 'Date', with: '2021-01-01'
       fill_in 'Description', with: 'My New Transaction'
       select 'Income', from: 'Transaction type'
-      fill_in 'Amount', with: '100'
+      fill_in 'Amount', with: '10000'
       click_on 'Create Transaction'
 
       expect(page).to have_content('Transaction was successfully created')
@@ -80,11 +82,11 @@ RSpec.describe 'Transactions' do
       expect(transaction.description).to eq 'My New Transaction'
     end
 
-    it 'can be created as an expense with a standard category' do
+    it 'can be created as an expense with a standard category', :js do
       fill_in 'Date', with: '2021-01-01'
       fill_in 'Description', with: 'My New Transaction'
       select 'Expense', from: 'Transaction type'
-      fill_in 'Amount', with: '100'
+      fill_in 'Amount', with: '10000'
       select category.name, from: 'Category'
       click_on 'Create Transaction'
 
@@ -99,12 +101,12 @@ RSpec.describe 'Transactions' do
       expect(transaction.description).to eq 'My New Transaction'
     end
 
-    it 'can be created as an expense with a subcategory' do
+    it 'can be created as an expense with a subcategory', :js do
       subcategory_name = "#{subcategory.name} (Subcategory of #{category.name})"
       fill_in 'Date', with: '2021-01-01'
       fill_in 'Description', with: 'My New Transaction'
       select 'Expense', from: 'Transaction type'
-      fill_in 'Amount', with: '100'
+      fill_in 'Amount', with: '10000'
       select subcategory_name, from: 'Category'
       click_on 'Create Transaction'
 

--- a/spec/system/transactions_spec.rb
+++ b/spec/system/transactions_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe 'Transactions' do
     let!(:transaction) { create(:transaction, company:) }
 
     before do
+      click_on 'account_circle'
       click_on 'Transactions'
 
       click_on 'View'


### PR DESCRIPTION
## Why?

The Transactions needed some more polish before they would be ready for release

## What Changed

What changed in this PR?

* [x] Use built in scopes for transaction totals
* [x] Style the transaction pages
* [x] Style the header
* [x] Conditionally hide the category selection

## Health Checks

These can be done by entering `rake` in the terminal

* [x] rspec
* [x] rubocop
* [x] audit

## Screenshots
<img width="329" alt="Screenshot 2025-01-25 at 4 08 47 PM" src="https://github.com/user-attachments/assets/9cd7e016-1141-4a63-ba42-aa2942071eae" />
<img width="993" alt="Screenshot 2025-01-25 at 4 08 42 PM" src="https://github.com/user-attachments/assets/cd479580-b3fb-46a7-8dd1-c3c3dc7a8c0d" />
<img width="995" alt="Screenshot 2025-01-25 at 4 08 36 PM" src="https://github.com/user-attachments/assets/6ed9bf2e-c82e-4a56-8d44-61f7ae204079" />
<img width="992" alt="Screenshot 2025-01-25 at 4 08 31 PM" src="https://github.com/user-attachments/assets/006fb377-e6b1-47e2-b375-edfdb1c7188e" />
