### PR TITLE
Update dependabot.yml to group all dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  groups:
+      all-dependencies:
+        patterns:
+          - "*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
## Why?

I was annoyed with how many PRs dependabot was creating for small fixes and wanted it to combine them into individual PRs.

## What Changed

Changed the dependabot.yml