### PR TITLE
[MM#18] Form Quality of Life

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ gem 'propshaft'
 gem 'pg', '~> 1.1'
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '>= 5.0'
-# Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
-gem 'jsbundling-rails'
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem 'turbo-rails'
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
       money (~> 6.13)
       railties (>= 3.0)
     msgpack (1.7.5)
-    net-imap (0.5.5)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -222,7 +222,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.9)
+    rack (3.1.10)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,8 +143,6 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jsbundling-rails (1.3.1)
-      railties (>= 6.0.0)
     json (2.9.1)
     language_server-protocol (3.17.0.4)
     logger (1.6.5)
@@ -417,7 +415,6 @@ DEPENDENCIES
   dockerfile-rails (>= 1.7)
   factory_bot_rails
   jbuilder
-  jsbundling-rails
   money-rails
   pg (~> 1.1)
   propshaft

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -16,6 +16,7 @@ class TransactionsController < ApplicationController
   def new
     authorize Transaction
     @transaction = Transaction.new
+    @transaction.transaction_type = params[:transaction_type]
   end
 
   # GET /transactions/1/edit
@@ -24,12 +25,17 @@ class TransactionsController < ApplicationController
   end
 
   # POST /transactions or /transactions.json
-  def create
+  def create # rubocop:disable Metrics/MethodLength
     @transaction = Transaction.new(transaction_params)
     authorize @transaction
 
     if @transaction.save
-      redirect_to transactions_path, notice: 'Transaction was successfully created.'
+      if params[:submit_and_new] == 'true'
+        redirect_to new_transaction_path(transaction_type: @transaction.transaction_type),
+                    notice: 'Transaction was successfully created. Please create another.'
+      else
+        redirect_to transactions_path, notice: 'Transaction was successfully created.'
+      end
     else
       render :new, status: :unprocessable_entity
     end
@@ -45,11 +51,16 @@ class TransactionsController < ApplicationController
   end
 
   # PATCH/PUT /transactions/1 or /transactions/1.json
-  def update
+  def update # rubocop:disable Metrics/MethodLength
     authorize @transaction
 
     if @transaction.update(transaction_params)
-      redirect_to transactions_path, notice: 'Transaction was successfully updated.'
+      if params[:submit_and_new] == 'true'
+        redirect_to new_transaction_path(transaction_type: @transaction.transaction_type),
+                    notice: 'Transaction was successfully updated. Please create another.'
+      else
+        redirect_to transactions_path, notice: 'Transaction was successfully updated.'
+      end
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/javascript/controllers/date_input_controller.js
+++ b/app/javascript/controllers/date_input_controller.js
@@ -6,7 +6,7 @@ import flatpickr from "flatpickr"
 export default class extends Controller {
   connect() {
     flatpickr(this.element, {
-      allowInput: true,
+      allowInput: true
     })
   }
 }

--- a/app/javascript/controllers/money_input_controller.js
+++ b/app/javascript/controllers/money_input_controller.js
@@ -31,6 +31,8 @@ export default class extends Controller {
   }
 
   handleKeydown(event) {
+    if (event.key ==="Enter") return
+
     event.preventDefault()
 
     if (isFinite(event.key) && this.value.toString().length < this.maxDigits) {

--- a/app/views/companies/_form.html.slim
+++ b/app/views/companies/_form.html.slim
@@ -1,3 +1,3 @@
-= simple_form_for @company do |f|
+= simple_form_for @company, html: { autocomplete: 'off' } do |f|
   = f.input :name
   = f.button :submit, class: 'btn btn--primary'

--- a/app/views/subcategories/_form.html.slim
+++ b/app/views/subcategories/_form.html.slim
@@ -1,6 +1,6 @@
 -# locals: (show_delete_button: false)
 
-= simple_form_for @subcategory do |f|
+= simple_form_for @subcategory, html: { autocomplete: 'off' } do |f|
   = f.hidden_field :company_id, value: current_company.id
 
   = f.input :name

--- a/app/views/subcategories/_form.html.slim
+++ b/app/views/subcategories/_form.html.slim
@@ -2,7 +2,7 @@
   = f.hidden_field :company_id, value: current_company.id
 
   = f.input :name
-  = f.input :category_id, collection: Category.all
+  = f.input :category_id, collection: Category.all, required: true
 
 
 .flex.justify-between

--- a/app/views/subcategories/_form.html.slim
+++ b/app/views/subcategories/_form.html.slim
@@ -1,5 +1,3 @@
--# locals: (show_delete_button: false)
-
 = simple_form_for @subcategory, html: { autocomplete: 'off' } do |f|
   = f.hidden_field :company_id, value: current_company.id
 
@@ -8,6 +6,7 @@
 
 
 .flex.justify-between
+  - show_delete_button = action_name === 'update' || action_name === 'edit'
   - if show_delete_button && policy(@subcategory).destroy?
     = button_to 'Delete Subcategory', subcategory_path(@subcategory), method: :delete, data: { turbo_confirm: 'Are you sure?' }, class: 'btn btn--destructive'
 

--- a/app/views/subcategories/edit.html.slim
+++ b/app/views/subcategories/edit.html.slim
@@ -4,4 +4,4 @@
     = material_icon 'arrow_back'
     | Back
 
-= render 'form', show_delete_button: true
+= render 'form'

--- a/app/views/transactions/_form.html.slim
+++ b/app/views/transactions/_form.html.slim
@@ -1,6 +1,6 @@
 -# locals: (show_delete_button: false)
 
-= simple_form_for @transaction do |f|
+= simple_form_for @transaction, html: { autocomplete: 'off' } do |f|
   div data-controller='conditional-input' data-conditional-input-condition-value='expense'
     = f.hidden_field :company_id, value: current_company.id
 

--- a/app/views/transactions/_form.html.slim
+++ b/app/views/transactions/_form.html.slim
@@ -10,7 +10,9 @@
       = f.input :transaction_type, collection: transaction_type_options, include_blank: false, input_html: { data: { conditional_input_target: 'trigger' } }
 
     - options_for_categorizable = categorizable_options
-    = f.input :categorizable, label: 'Category', collection: options_for_categorizable, selected: selected_categorizable_option(f.object, options_for_categorizable), include_blank: true,
+    = f.input :categorizable, label: 'Category', collection: options_for_categorizable, selected: selected_categorizable_option(f.object, options_for_categorizable),
+        include_blank: true,
+        required: true,
         wrapper_html: { data: { conditional_input_target: 'conditionalInputWrapper' } },
         input_html: { data: {conditional_input_target: 'conditionalInput' } }
     = f.input :description

--- a/app/views/transactions/_form.html.slim
+++ b/app/views/transactions/_form.html.slim
@@ -1,5 +1,3 @@
--# locals: (show_delete_button: false)
-
 = simple_form_for @transaction, html: { autocomplete: 'off' } do |f|
   div data-controller='conditional-input' data-conditional-input-condition-value='expense'
     = f.hidden_field :company_id, value: current_company.id
@@ -18,6 +16,7 @@
     = f.input :description
 
 .flex.justify-between
+  - show_delete_button = action_name === 'update' || action_name === 'edit'
   - if show_delete_button && policy(@transaction).destroy?
     = button_to 'Delete Transaction', transaction_path(@transaction), method: :delete, data: { turbo_confirm: 'Are you sure?' }, class: 'btn btn--destructive'
 

--- a/app/views/transactions/_form.html.slim
+++ b/app/views/transactions/_form.html.slim
@@ -20,5 +20,7 @@
   - if show_delete_button && policy(@transaction).destroy?
     = button_to 'Delete Transaction', transaction_path(@transaction), method: :delete, data: { turbo_confirm: 'Are you sure?' }, class: 'btn btn--destructive'
 
-  - submit_text = action_name === 'new'|| action_name === 'create' ? 'Create Transaction' : 'Update Transaction'
-  = submit_button @transaction, submit_text, class: 'btn btn--primary'
+  .flex.gap-md
+    - submit_text = action_name === 'new'|| action_name === 'create' ? 'Create Transaction' : 'Update Transaction'
+    = submit_button @transaction, submit_text, class: 'btn btn--primary'
+    = submit_button @transaction, submit_text + ' and New', class: 'btn', name: 'submit_and_new', value: 'true'

--- a/app/views/transactions/edit.html.slim
+++ b/app/views/transactions/edit.html.slim
@@ -4,4 +4,4 @@
     = material_icon 'arrow_back'
     | Back
 
-= render 'form', show_delete_button: true
+= render 'form'


### PR DESCRIPTION
## Why?

There were some issues the users had found where chrome on windows would open autocomplete prompts for all form inputs. They also expressed the desire for create/update and new buttons so they could easily and efficiently create multiple income or expense transactions. One last thing is that forms do not submit when the `enter` key is hit which reduces user speed.

## What Changed

What changed in this PR?

* [x] Added `autocomplete: 'off'` to all forms
* [x] Created a create/update and new button for transactions which saves the current transaction and then directs you to a new page with the transaction_type already selected.
* [x] Make category labels on transaction and subcategory forms required
* [x] Make money input submit on enter
* [x] Removed `jsbundling-rails` as it wasn't needed

## Health Checks

These can be done by entering `rake` in the terminal

* [x] rspec
* [x] rubocop
* [x] audit

## Screenshots

<img width="988" alt="Screenshot 2025-02-15 at 8 35 12 PM" src="https://github.com/user-attachments/assets/7adf1d3b-0742-4899-b2ec-822a5ffd3dd5" />
<img width="992" alt="Screenshot 2025-02-15 at 8 37 29 PM" src="https://github.com/user-attachments/assets/559cd90d-b15e-4937-98a0-9607bef99c0c" />

