### PR TITLE
[MM-19] Separate Expenses and Income

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
-require:
+plugins:
   - rubocop-rails
-  - rubocop-capybara
   - rubocop-rspec
+
+require:
+  - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rspec_rails
   - ./lib/cops/form_error_response.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,7 +82,7 @@ RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/ExampleLength:
-  Max: 15
+  Max: 25
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
 plugins:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-factory_bot
 
 require:
   - rubocop-capybara
-  - rubocop-factory_bot
   - rubocop-rspec_rails
   - ./lib/cops/form_error_response.rb
 

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem 'rolemodel_sower'
 # Use Pundit for permissions
 gem 'pundit'
 
+gem 'kaminari'
+
 gem 'rubocop'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,18 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.10.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.6.6)
@@ -423,6 +435,7 @@ DEPENDENCIES
   factory_bot_rails
   jbuilder
   jsbundling-rails
+  kaminari
   money-rails
   pg (~> 1.1)
   propshaft

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,6 +14,7 @@
  @import 'components/optics-overrides/form.css';
  @import 'components/optics-overrides/layout.css';
  @import 'components/optics-overrides/navbar.css';
+ @import 'components/optics-overrides/pagination.css';
  @import 'components/optics-overrides/table.css';
 
  /* devise */

--- a/app/assets/stylesheets/components/optics-overrides/pagination.css
+++ b/app/assets/stylesheets/components/optics-overrides/pagination.css
@@ -1,0 +1,4 @@
+.pagination {
+  padding-inline: var(--op-space-medium);
+  gap: var(--op-space-2x-small);
+}

--- a/app/assets/stylesheets/components/optics-overrides/table.css
+++ b/app/assets/stylesheets/components/optics-overrides/table.css
@@ -8,6 +8,19 @@
     .table--transactions__actions {
       width: calc(18.75 * var(--op-size-unit)); /* 75px */
     }
+
+    .table--transactions__totals {
+      display: flex;
+      gap: var(--op-space-medium);
+
+      .table--transactions__totals-pair {
+        display: flex;
+        flex-direction: column;
+        gap: var(--op-space-small);
+
+        text-align: center;
+      }
+    }
   }
 
   .table__actions {

--- a/app/assets/stylesheets/components/optics-overrides/table.css
+++ b/app/assets/stylesheets/components/optics-overrides/table.css
@@ -11,12 +11,14 @@
 
     .table--transactions__totals {
       display: flex;
+      justify-content: end;
       gap: var(--op-space-medium);
+      padding-inline: var(--op-space-medium);
 
       .table--transactions__totals-pair {
         display: flex;
         flex-direction: column;
-        gap: var(--op-space-small);
+        gap: var(--op-space-2x-small);
 
         text-align: center;
       }

--- a/app/assets/stylesheets/components/page-header.css
+++ b/app/assets/stylesheets/components/page-header.css
@@ -1,5 +1,24 @@
 .page-header {
   display: flex;
-  justify-content: space-between;
   padding-bottom: var(--op-space-medium);
+
+  >* {
+    flex: 1;
+    width: fit-content;
+
+    &:first-child {
+      display: flex;
+      justify-content: start;
+    }
+
+    &:not(:first-child):not(:last-child) {
+      display: flex;
+      justify-content: center;
+    }
+
+    &:last-child {
+      display: flex;
+      justify-content: end;
+    }
+  }
 }

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -73,7 +73,7 @@ class TransactionsController < ApplicationController
   private
 
   def session_transaction_grouping
-    session[:transaction_grouping] || DEFAULT_TRANSACTION_GROUPING
+    session[:transaction_grouping]&.to_sym || DEFAULT_TRANSACTION_GROUPING
   end
 
   def set_session_transaction_grouping

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -72,7 +72,7 @@ class TransactionsController < ApplicationController
   private
 
   def session_transaction_grouping
-    session[:transaction_grouping].to_sym || DEFAULT_TRANSACTION_GROUPING
+    session[:transaction_grouping] || DEFAULT_TRANSACTION_GROUPING
   end
 
   def set_session_transaction_grouping

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -13,6 +13,7 @@ class TransactionsController < ApplicationController
     set_session_transaction_grouping
 
     @transactions_presenter = TransactionsPresenter.new(current_company, session_transaction_grouping)
+    @transactions = @transactions_presenter.transactions.page(params[:page])
   end
 
   # GET /transactions/new

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -13,7 +13,7 @@ class Transaction < ApplicationRecord
   validates :categorizable, absence: { message: 'cannot be present for income transactions' }, if: -> { income? }
   validates :categorizable, presence: { message: 'must be present for expense transactions' }, if: -> { expense? }
 
-  paginates_per 50
+  paginates_per 25
 
   def categorizable=(categorizable)
     if categorizable.is_a?(String) # Check if it is a signed global id

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -13,6 +13,8 @@ class Transaction < ApplicationRecord
   validates :categorizable, absence: { message: 'cannot be present for income transactions' }, if: -> { income? }
   validates :categorizable, presence: { message: 'must be present for expense transactions' }, if: -> { expense? }
 
+  paginates_per 50
+
   def categorizable=(categorizable)
     if categorizable.is_a?(String) # Check if it is a signed global id
       super(GlobalID::Locator.locate_signed(categorizable))

--- a/app/presenters/transactions_presenter.rb
+++ b/app/presenters/transactions_presenter.rb
@@ -28,6 +28,24 @@ class TransactionsPresenter
     grouping == :expense ? :expense : :income
   end
 
+  def show_category?
+    grouping != :income
+  end
+
+  def show_transaction_type?
+    grouping == :all
+  end
+
+  def pagination_colspan
+    if show_category? && show_transaction_type?
+      3
+    elsif show_category? || show_transaction_type?
+      2
+    else
+      1
+    end
+  end
+
   private
 
   def authorized_transactions

--- a/app/presenters/transactions_presenter.rb
+++ b/app/presenters/transactions_presenter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class TransactionsPresenter
+  attr_reader :company, :grouping
+
+  def initialize(company, grouping)
+    @company = company
+    @grouping = grouping
+  end
+
+  def transactions
+    authorized_transactions.send(grouping).order(date: :desc)
+  end
+
+  def total_income
+    authorized_transactions.income.sum(:amount_cents) / 100
+  end
+
+  def total_expense
+    authorized_transactions.expense.sum(:amount_cents) / 100
+  end
+
+  def balance
+    total_income - total_expense
+  end
+
+  def transaction_type
+    grouping == :expense ? :expense : :income
+  end
+
+  private
+
+  def authorized_transactions
+    @authorized_transactions ||= company.transactions
+  end
+end

--- a/app/views/companies/edit.html.slim
+++ b/app/views/companies/edit.html.slim
@@ -1,7 +1,8 @@
 .page-header
-  h1 Edit #{@company.name}
-  = link_to companies_path, class: 'btn' do
-    = material_icon 'arrow_back'
-    | Back
+  h1.page-header__item Edit #{@company.name}
+  .page-header__item
+    = link_to companies_path, class: 'btn' do
+      = material_icon 'arrow_back'
+      | Back
 
 = render 'form'

--- a/app/views/companies/new.html.slim
+++ b/app/views/companies/new.html.slim
@@ -1,8 +1,9 @@
 .page-header
-  h1 Create New Company
-  = link_to companies_path, class: 'btn' do
-    = material_icon 'arrow_back'
-    | Back
+  h1.page-header__item Create New Company
+  .page-header__item
+    = link_to companies_path, class: 'btn' do
+      = material_icon 'arrow_back'
+      | Back
 
 = render 'form'
 

--- a/app/views/devise/invitations/new.html.slim
+++ b/app/views/devise/invitations/new.html.slim
@@ -1,7 +1,7 @@
 .page-header
-  .page-header__title = t "devise.invitations.new.header"
+  .page-header__item = t "devise.invitations.new.header"
 
-  .breadcrumbs
+  .page-header__item.breadcrumbs
     = link_to 'Dashboard', root_path, class: 'breadcrumbs__link'
     .breadcrumbs__separator
       = material_icon('arrow_right')

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,6 +1,6 @@
 - content_for :header do
   .page-header
-    .page-header__title = t(".title", resource: resource_name.to_s.humanize, default: "Edit %{resource}")
+    .page-header__item = t(".title", resource: resource_name.to_s.humanize, default: "Edit %{resource}")
 
 .page-sections
   = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'card' }) do |f|

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,9 @@
+/ Link to the "First" page
+  - available local variables
+    url          : url to the first page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+== link_to_unless current_page.first?, material_icon('first_page'), url, remote: remote, class: 'btn btn--small btn--no-border btn--icon'

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,8 @@
+/ Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+.pagination__divider ...

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,9 @@
+/ Link to the "Last" page
+  - available local variables
+    url          : url to the last page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+== link_to_unless current_page.last?, material_icon('last_page'), url, remote: remote, class: 'btn btn--small btn--no-border btn--icon'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,12 @@
+/ Link to the "Next" page
+  - available local variables
+    url          : url to the next page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+- unless current_page.last?
+  = link_to url, rel: 'next', remote: remote, class: 'btn btn--small btn--no-border' do
+    | Next
+    = material_icon('chevron_right')

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,10 @@
+/ Link showing page number
+  - available local variables
+    page         : a page object for "this" page
+    url          : url to this page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+= link_to page, url, { remote: remote, rel: page.rel, class: "btn btn--no-border btn--small #{'btn--active' if page.current? }" }

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,19 @@
+/ The container tag
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+    paginator    : the paginator that renders the pagination tags inside
+
+== paginator.render do
+  nav.pagination
+    == first_page_tag unless current_page.first?
+    == prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.display_tag?
+        == page_tag page
+      - elsif !page.was_truncated?
+        == gap_tag
+    == next_page_tag unless current_page.last?
+    == last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,12 @@
+/ Link to the "Previous" page
+  - available local variables
+    url          : url to the previous page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+
+- unless current_page.first?
+  = link_to url, rel: 'prev', remote: remote, class: 'btn btn--small btn--no-border' do
+    = material_icon('chevron_left')
+    | Prev

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,4 +1,4 @@
-.app-header
+.app__header
   .navbar
     a.navbar__brand href="/"
       = image_tag 'logo.png', alt: 'Logo'

--- a/app/views/subcategories/edit.html.slim
+++ b/app/views/subcategories/edit.html.slim
@@ -1,7 +1,8 @@
 .page-header
-  h1 Edit #{@subcategory.name}
-  = link_to subcategories_path, class: 'btn' do
-    = material_icon 'arrow_back'
-    | Back
+  h1.page-header__item Edit #{@subcategory.name}
+  .page-header__item
+    = link_to subcategories_path, class: 'btn' do
+      = material_icon 'arrow_back'
+      | Back
 
 = render 'form'

--- a/app/views/subcategories/index.html.slim
+++ b/app/views/subcategories/index.html.slim
@@ -1,7 +1,8 @@
 .page-header
-  h1 Subcategories
-  - if policy(Subcategory).new?
-    = link_to 'New Subcategory', new_subcategory_path, class: 'btn'
+  h1.page-header__item Subcategories
+  .page-header__item
+    - if policy(Subcategory).new?
+      = link_to 'New Subcategory', new_subcategory_path, class: 'btn'
 
 table.table
   thead

--- a/app/views/subcategories/new.html.slim
+++ b/app/views/subcategories/new.html.slim
@@ -1,7 +1,8 @@
 .page-header
-  h1 Create New Subcategory
-  = link_to subcategories_path, class: 'btn' do
-    = material_icon 'arrow_back'
-    | Back
+  h1.page-header__item Create New Subcategory
+  .page-header__item
+    = link_to subcategories_path, class: 'btn' do
+      = material_icon 'arrow_back'
+      | Back
 
 = render 'form'

--- a/app/views/transactions/edit.html.slim
+++ b/app/views/transactions/edit.html.slim
@@ -1,7 +1,8 @@
 .page-header
-  h1 Update Transaction
-  = link_to transactions_path, class: 'btn' do
-    = material_icon 'arrow_back'
-    | Back
+  h1.page-header__item Update Transaction
+  .page-header__item
+    = link_to transactions_path, class: 'btn' do
+      = material_icon 'arrow_back'
+      | Back
 
 = render 'form'

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -15,8 +15,10 @@ table.table.table--sticky-header.table--sticky-footer.table--primary.table--comf
   thead
     tr
       th.table--transactions__date Date
-      th.table--transactions__type Type
-      th Category
+      - if @transactions_presenter.show_transaction_type?
+        th.table--transactions__type Type
+      - if @transactions_presenter.show_category?
+        th Category
       th Description
       th Amount
       th.table--transactions__actions
@@ -24,15 +26,17 @@ table.table.table--sticky-header.table--sticky-footer.table--primary.table--comf
     - @transactions.each do |transaction|
       tr
         td = transaction.date
-        td = transaction.transaction_type.humanize
-        td = transaction.categorizable_name
+        - if @transactions_presenter.show_transaction_type?
+          td = transaction.transaction_type.humanize
+        - if @transactions_presenter.show_category?
+          td = transaction.categorizable_name
         td = transaction.description
         td = number_to_currency(transaction.amount)
         - if policy(transaction).edit?
           td = link_to 'View', edit_transaction_path(transaction), class: 'btn btn--small'
   tfoot
     tr
-      td colspan="3"
+      td colspan="#{@transactions_presenter.pagination_colspan}"
         = paginate @transactions
       td colspan="3"
         .table--transactions__totals

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -18,7 +18,7 @@ table.table.table--sticky-header.table--sticky-footer.table--primary.table--comf
       th Amount
       th.table--transactions__actions
   tbody
-    - @transactions_presenter.transactions.each do |transaction|
+    - @transactions.each do |transaction|
       tr
         td = transaction.date
         td = transaction.transaction_type.humanize
@@ -29,16 +29,18 @@ table.table.table--sticky-header.table--sticky-footer.table--primary.table--comf
           td = link_to 'View', edit_transaction_path(transaction), class: 'btn btn--small'
   tfoot
     tr
+      td colspan="4"
+        = paginate @transactions
       td colspan="2"
-      td
-        | Total Income
-        br
-        = number_to_currency(@transactions_presenter.total_income)
-      td
-        | Total Expense
-        br
-        = number_to_currency(@transactions_presenter.total_expense)
-      td colspan="2"
-        | Total Balance
-        br
-        = number_to_currency(@transactions_presenter.balance)
+        .table--transactions__totals
+          .table--transactions__totals-pair
+            span Total Income
+            span = number_to_currency(@transactions_presenter.total_income)
+          .table--transactions__totals-pair
+            span Total Expense
+            span = number_to_currency(@transactions_presenter.total_expense)
+          .table--transactions__totals-pair
+            span Total Balance
+            span = number_to_currency(@transactions_presenter.balance)
+
+= paginate @transactions

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -3,7 +3,7 @@
   - if policy(Transaction).new?
     = link_to 'New Transaction', new_transaction_path, class: 'btn'
 
-table.table.table--primary.table--comfortable-density.table--transactions
+table.table.table--sticky-header.table--sticky-footer.table--primary.table--comfortable-density.table--transactions
   thead
     tr
       th.table--transactions__date Date

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -1,7 +1,12 @@
 .page-header
+  .btn-group
+    - grouping = @transactions_presenter.grouping
+    = link_to 'Income', transactions_path(transaction_grouping: :income), class: class_names('btn', 'btn--active': grouping == :income)
+    = link_to 'All', transactions_path(transaction_grouping: :all), class: class_names('btn', 'btn--active': grouping == :all)
+    = link_to 'Expense', transactions_path(transaction_grouping: :expense), class: class_names('btn', 'btn--active': grouping == :expense)
   h1 Transactions
   - if policy(Transaction).new?
-    = link_to 'New Transaction', new_transaction_path, class: 'btn'
+    = link_to 'New Transaction', new_transaction_path(transaction_type: @transactions_presenter.transaction_type), class: 'btn'
 
 table.table.table--sticky-header.table--sticky-footer.table--primary.table--comfortable-density.table--transactions
   thead
@@ -13,7 +18,7 @@ table.table.table--sticky-header.table--sticky-footer.table--primary.table--comf
       th Amount
       th.table--transactions__actions
   tbody
-    - @transactions.each do |transaction|
+    - @transactions_presenter.transactions.each do |transaction|
       tr
         td = transaction.date
         td = transaction.transaction_type.humanize
@@ -28,12 +33,12 @@ table.table.table--sticky-header.table--sticky-footer.table--primary.table--comf
       td
         | Total Income
         br
-        = number_to_currency(@total_income)
+        = number_to_currency(@transactions_presenter.total_income)
       td
         | Total Expense
         br
-        = number_to_currency(@total_expense)
+        = number_to_currency(@transactions_presenter.total_expense)
       td colspan="2"
         | Total Balance
         br
-        = number_to_currency(@total_income - @total_expense)
+        = number_to_currency(@transactions_presenter.balance)

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -5,8 +5,7 @@
       = link_to 'Income', transactions_path(transaction_grouping: :income), class: class_names('btn', 'btn--active': grouping == :income)
       = link_to 'All', transactions_path(transaction_grouping: :all), class: class_names('btn', 'btn--active': grouping == :all)
       = link_to 'Expense', transactions_path(transaction_grouping: :expense), class: class_names('btn', 'btn--active': grouping == :expense)
-  .page-header__item
-    h1 Transactions
+  h1.page-header__item Transactions
   - if policy(Transaction).new?
     .page-header__item
       = link_to 'New Transaction', new_transaction_path(transaction_type: @transactions_presenter.transaction_type), class: 'btn'

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -1,12 +1,15 @@
 .page-header
-  .btn-group
-    - grouping = @transactions_presenter.grouping
-    = link_to 'Income', transactions_path(transaction_grouping: :income), class: class_names('btn', 'btn--active': grouping == :income)
-    = link_to 'All', transactions_path(transaction_grouping: :all), class: class_names('btn', 'btn--active': grouping == :all)
-    = link_to 'Expense', transactions_path(transaction_grouping: :expense), class: class_names('btn', 'btn--active': grouping == :expense)
-  h1 Transactions
+  .page-header__item
+    .btn-group
+      - grouping = @transactions_presenter.grouping
+      = link_to 'Income', transactions_path(transaction_grouping: :income), class: class_names('btn', 'btn--active': grouping == :income)
+      = link_to 'All', transactions_path(transaction_grouping: :all), class: class_names('btn', 'btn--active': grouping == :all)
+      = link_to 'Expense', transactions_path(transaction_grouping: :expense), class: class_names('btn', 'btn--active': grouping == :expense)
+  .page-header__item
+    h1 Transactions
   - if policy(Transaction).new?
-    = link_to 'New Transaction', new_transaction_path(transaction_type: @transactions_presenter.transaction_type), class: 'btn'
+    .page-header__item
+      = link_to 'New Transaction', new_transaction_path(transaction_type: @transactions_presenter.transaction_type), class: 'btn'
 
 table.table.table--sticky-header.table--sticky-footer.table--primary.table--comfortable-density.table--transactions
   thead
@@ -29,9 +32,9 @@ table.table.table--sticky-header.table--sticky-footer.table--primary.table--comf
           td = link_to 'View', edit_transaction_path(transaction), class: 'btn btn--small'
   tfoot
     tr
-      td colspan="4"
+      td colspan="3"
         = paginate @transactions
-      td colspan="2"
+      td colspan="3"
         .table--transactions__totals
           .table--transactions__totals-pair
             span Total Income
@@ -42,5 +45,3 @@ table.table.table--sticky-header.table--sticky-footer.table--primary.table--comf
           .table--transactions__totals-pair
             span Total Balance
             span = number_to_currency(@transactions_presenter.balance)
-
-= paginate @transactions

--- a/app/views/transactions/new.html.slim
+++ b/app/views/transactions/new.html.slim
@@ -1,8 +1,9 @@
 .page-header
-  h1 Create New Transaction
-  = link_to transactions_path, class: 'btn' do
-    = material_icon 'arrow_back'
-    | Back
+  h1.page-header__item Create New Transaction
+  .page-header__item
+    = link_to transactions_path, class: 'btn' do
+      = material_icon 'arrow_back'
+      | Back
 
 = render 'form'
 

--- a/spec/presenters/transactions_presenter_spec.rb
+++ b/spec/presenters/transactions_presenter_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TransactionsPresenter do
+  let(:presenter) { described_class.new(company, grouping) }
+  let(:company) { create(:company) }
+  let(:grouping) { :all }
+
+  before do
+    create_list(:transaction, 2) # create transactions for other companies
+
+    create_list(:transaction, 2, :expense, company:)
+    create_list(:transaction, 2, :income, company:)
+  end
+
+  describe '#transactions' do
+    context 'when grouping is all' do
+      let(:grouping) { :all }
+
+      it 'returns all the correct company\'s transactions ordered by date' do
+        expected_transactions = company.transactions.order(date: :desc)
+        received_transactions = presenter.transactions
+
+        expect(received_transactions).to eq(expected_transactions)
+      end
+    end
+
+    context 'when grouping is income' do
+      let(:grouping) { :income }
+
+      it 'returns all income the correct company\'s transactions ordered by date' do
+        expected_transactions = company.transactions.income.order(date: :desc)
+        received_transactions = presenter.transactions
+
+        expect(received_transactions).to eq(expected_transactions)
+      end
+    end
+
+    context 'when grouping is expense' do
+      let(:grouping) { :expense }
+
+      it 'returns all expense the correct company\'s transactions ordered by date' do
+        expected_transactions = company.transactions.expense.order(date: :desc)
+        received_transactions = presenter.transactions
+
+        expect(received_transactions).to eq(expected_transactions)
+      end
+    end
+  end
+
+  describe '#total_income' do
+    it 'returns the total income' do
+      expected_total_income = company.transactions.income.sum(:amount_cents) / 100
+      received_total_income = presenter.total_income
+
+      expect(received_total_income).to eq(expected_total_income)
+    end
+  end
+
+  describe '#total_expense' do
+    it 'returns the total expense' do
+      expected_total_expense = company.transactions.expense.sum(:amount_cents) / 100
+      received_total_expense = presenter.total_expense
+
+      expect(received_total_expense).to eq(expected_total_expense)
+    end
+  end
+
+  describe '#balance' do
+    it 'returns the balance' do
+      expected_balance = presenter.total_income - presenter.total_expense
+      received_balance = presenter.balance
+
+      expect(received_balance).to eq(expected_balance)
+    end
+  end
+
+  describe '#transaction_type' do
+    context 'when grouping is expense' do
+      let(:grouping) { :expense }
+
+      it 'returns expense' do
+        expect(presenter.transaction_type).to eq(:expense)
+      end
+    end
+
+    context 'when grouping is income' do
+      let(:grouping) { :income }
+
+      it 'returns income' do
+        expect(presenter.transaction_type).to eq(:income)
+      end
+    end
+
+    context 'when grouping is all' do
+      let(:grouping) { :all }
+
+      it 'returns income as default' do
+        expect(presenter.transaction_type).to eq(:income)
+      end
+    end
+  end
+end

--- a/spec/presenters/transactions_presenter_spec.rb
+++ b/spec/presenters/transactions_presenter_spec.rb
@@ -101,4 +101,82 @@ RSpec.describe TransactionsPresenter do
       end
     end
   end
+
+  describe '#show_category?' do
+    context 'when grouping is expense' do
+      let(:grouping) { :expense }
+
+      it 'returns true' do
+        expect(presenter.show_category?).to be true
+      end
+    end
+
+    context 'when grouping is income' do
+      let(:grouping) { :income }
+
+      it 'returns false' do
+        expect(presenter.show_category?).to be false
+      end
+    end
+
+    context 'when grouping is all' do
+      let(:grouping) { :all }
+
+      it 'returns true' do
+        expect(presenter.show_category?).to be true
+      end
+    end
+  end
+
+  describe '#show_transaction_type?' do
+    context 'when grouping is expense' do
+      let(:grouping) { :expense }
+
+      it 'returns false' do
+        expect(presenter.show_transaction_type?).to be false
+      end
+    end
+
+    context 'when grouping is income' do
+      let(:grouping) { :income }
+
+      it 'returns false' do
+        expect(presenter.show_transaction_type?).to be false
+      end
+    end
+
+    context 'when grouping is all' do
+      let(:grouping) { :all }
+
+      it 'returns true' do
+        expect(presenter.show_transaction_type?).to be true
+      end
+    end
+  end
+
+  describe '#pagination_colspan' do
+    context 'when grouping is expense' do
+      let(:grouping) { :expense }
+
+      it 'returns 2' do
+        expect(presenter.pagination_colspan).to eq(2)
+      end
+    end
+
+    context 'when grouping is income' do
+      let(:grouping) { :income }
+
+      it 'returns 1' do
+        expect(presenter.pagination_colspan).to eq(1)
+      end
+    end
+
+    context 'when grouping is all' do
+      let(:grouping) { :all }
+
+      it 'returns 3' do
+        expect(presenter.pagination_colspan).to eq(3)
+      end
+    end
+  end
 end

--- a/spec/system/transactions_spec.rb
+++ b/spec/system/transactions_spec.rb
@@ -36,7 +36,11 @@ RSpec.describe 'Transactions' do
         expect(page).to have_content('Transactions')
 
         within('tbody') do
-          expect_transactions_to_be_listed([income_transaction, income_transaction2])
+          expect_transactions_to_be_listed(
+            [income_transaction, income_transaction2],
+            show_type: false,
+            show_category: true
+          )
           expect_transactions_not_to_be_listed([expense_transaction, expense_transaction2])
         end
       end
@@ -51,8 +55,9 @@ RSpec.describe 'Transactions' do
         expect(page).to have_content('Transactions')
 
         within('tbody') do
-          expect_transactions_to_be_listed([income_transaction, income_transaction2, expense_transaction,
-expense_transaction2])
+          expect_transactions_to_be_listed(
+            [income_transaction, income_transaction2, expense_transaction, expense_transaction2]
+          )
         end
       end
     end
@@ -66,7 +71,11 @@ expense_transaction2])
         expect(page).to have_content('Transactions')
 
         within('tbody') do
-          expect_transactions_to_be_listed([expense_transaction, expense_transaction2])
+          expect_transactions_to_be_listed(
+            [expense_transaction, expense_transaction2],
+            show_type: false,
+            show_category: true
+          )
           expect_transactions_not_to_be_listed([income_transaction, income_transaction2])
         end
       end
@@ -226,22 +235,19 @@ expense_transaction2])
     end
   end
 
-  def expect_transactions_to_be_listed(transactions) # rubocop:disable Metrics/AbcSize
+  def expect_transactions_to_be_listed(transactions, show_type: true, show_category: true) # rubocop:disable Metrics/AbcSize
     transactions.each do |transaction|
       expect(page).to have_content transaction.date
       expect(page).to have_content transaction.description
-      expect(page).to have_content transaction.transaction_type.titleize
-      expect(page).to have_content transaction.categorizable&.name if transaction.categorizable.present?
+      expect(page).to have_content transaction.transaction_type.titleize if show_type
+      expect(page).to have_content transaction.categorizable&.name if show_category
       expect(page).to have_content transaction.amount.format
     end
   end
 
-  def expect_transactions_not_to_be_listed(transactions) # rubocop:disable Metrics/AbcSize
+  def expect_transactions_not_to_be_listed(transactions)
     transactions.each do |transaction|
-      expect(page).to have_no_content transaction.date
       expect(page).to have_no_content transaction.description
-      expect(page).to have_no_content transaction.transaction_type.titleize
-      expect(page).to have_no_content transaction.categorizable&.name if transaction.categorizable.present?
       expect(page).to have_no_content transaction.amount.format
     end
   end

--- a/spec/system/transactions_spec.rb
+++ b/spec/system/transactions_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe 'Transactions' do
         expect(page).to have_content('Transactions')
 
         within('tbody') do
-          expect_transactions_to_be_listed([income_transaction, income_transaction2, expense_transaction, expense_transaction2])
+          expect_transactions_to_be_listed([income_transaction, income_transaction2, expense_transaction,
+expense_transaction2])
         end
       end
     end
@@ -180,7 +181,6 @@ RSpec.describe 'Transactions' do
         click_on 'All'
         click_on 'New Transaction'
         expect(page).to have_select('Transaction type', selected: 'Income')
-
       end
     end
 
@@ -226,7 +226,7 @@ RSpec.describe 'Transactions' do
     end
   end
 
-  def expect_transactions_to_be_listed(transactions)
+  def expect_transactions_to_be_listed(transactions) # rubocop:disable Metrics/AbcSize
     transactions.each do |transaction|
       expect(page).to have_content transaction.date
       expect(page).to have_content transaction.description
@@ -236,13 +236,13 @@ RSpec.describe 'Transactions' do
     end
   end
 
-  def expect_transactions_not_to_be_listed(transactions)
+  def expect_transactions_not_to_be_listed(transactions) # rubocop:disable Metrics/AbcSize
     transactions.each do |transaction|
-      expect(page).not_to have_content transaction.date
-      expect(page).not_to have_content transaction.description
-      expect(page).not_to have_content transaction.transaction_type.titleize
-      expect(page).not_to have_content transaction.categorizable&.name if transaction.categorizable.present?
-      expect(page).not_to have_content transaction.amount.format
+      expect(page).to have_no_content transaction.date
+      expect(page).to have_no_content transaction.description
+      expect(page).to have_no_content transaction.transaction_type.titleize
+      expect(page).to have_no_content transaction.categorizable&.name if transaction.categorizable.present?
+      expect(page).to have_no_content transaction.amount.format
     end
   end
 end


### PR DESCRIPTION
## Why?

For easier viewing, the transaction view needed to be tabbed between 'Income', 'All', and 'Expense' transactions. The table footer should also be sticky to preserve that information. The transactions also needed to be paginated.

Note: there is an issue with the table header that needs to be addressed in the future.

## What Changed

* [x] Create a session variable to handle the tabbed views
* [x] Make the form pre-fill the transaction type with whichever tab is currently selected (income for all selected)
* [x] Make the table footer sticky
* [x] Fix the navbar fixed position
* [x] Paginate the transactions

## Health Checks

These can be done by entering `rake` in the terminal

* [x] rspec
* [x] rubocop
* [x] audit

## Screenshots

<img width="1034" alt="Screenshot 2025-03-08 at 3 59 42 PM" src="https://github.com/user-attachments/assets/baabcd58-e386-41ee-8605-d665aa512cf8" />
