### PR TITLE
Fix Table Layout

### DIFF
--- a/app/assets/stylesheets/components/optics-overrides/layout.css
+++ b/app/assets/stylesheets/components/optics-overrides/layout.css
@@ -1,4 +1,6 @@
 .app__content {
+  overflow: auto;
+  width: 100%;
   padding-block: var(--op-space-3x-large);
 }
 

--- a/app/assets/stylesheets/components/optics-overrides/table.css
+++ b/app/assets/stylesheets/components/optics-overrides/table.css
@@ -1,3 +1,8 @@
+.table-container {
+  overflow-y: auto;
+  max-height: 90%;
+}
+
 .table {
   &.table--transactions {
     .table--transactions__type,

--- a/app/views/transactions/index.html.slim
+++ b/app/views/transactions/index.html.slim
@@ -10,41 +10,42 @@
     .page-header__item
       = link_to 'New Transaction', new_transaction_path(transaction_type: @transactions_presenter.transaction_type), class: 'btn'
 
-table.table.table--sticky-header.table--sticky-footer.table--primary.table--comfortable-density.table--transactions
-  thead
-    tr
-      th.table--transactions__date Date
-      - if @transactions_presenter.show_transaction_type?
-        th.table--transactions__type Type
-      - if @transactions_presenter.show_category?
-        th Category
-      th Description
-      th Amount
-      th.table--transactions__actions
-  tbody
-    - @transactions.each do |transaction|
+.table-container
+  table.table.table--sticky-header.table--sticky-footer.table--primary.table--comfortable-density.table--transactions
+    thead
       tr
-        td = transaction.date
+        th.table--transactions__date Date
         - if @transactions_presenter.show_transaction_type?
-          td = transaction.transaction_type.humanize
+          th.table--transactions__type Type
         - if @transactions_presenter.show_category?
-          td = transaction.categorizable_name
-        td = transaction.description
-        td = number_to_currency(transaction.amount)
-        - if policy(transaction).edit?
-          td = link_to 'View', edit_transaction_path(transaction), class: 'btn btn--small'
-  tfoot
-    tr
-      td colspan="#{@transactions_presenter.pagination_colspan}"
-        = paginate @transactions
-      td colspan="3"
-        .table--transactions__totals
-          .table--transactions__totals-pair
-            span Total Income
-            span = number_to_currency(@transactions_presenter.total_income)
-          .table--transactions__totals-pair
-            span Total Expense
-            span = number_to_currency(@transactions_presenter.total_expense)
-          .table--transactions__totals-pair
-            span Total Balance
-            span = number_to_currency(@transactions_presenter.balance)
+          th Category
+        th Description
+        th Amount
+        th.table--transactions__actions
+    tbody
+      - @transactions.each do |transaction|
+        tr
+          td = transaction.date
+          - if @transactions_presenter.show_transaction_type?
+            td = transaction.transaction_type.humanize
+          - if @transactions_presenter.show_category?
+            td = transaction.categorizable_name
+          td = transaction.description
+          td = number_to_currency(transaction.amount)
+          - if policy(transaction).edit?
+            td = link_to 'View', edit_transaction_path(transaction), class: 'btn btn--small'
+    tfoot
+      tr
+        td colspan="#{@transactions_presenter.pagination_colspan}"
+          = paginate @transactions
+        td colspan="3"
+          .table--transactions__totals
+            .table--transactions__totals-pair
+              span Total Income
+              span = number_to_currency(@transactions_presenter.total_income)
+            .table--transactions__totals-pair
+              span Total Expense
+              span = number_to_currency(@transactions_presenter.total_expense)
+            .table--transactions__totals-pair
+              span Total Balance
+              span = number_to_currency(@transactions_presenter.balance)


### PR DESCRIPTION
## Why?

Following up the last release, I wanted to fix how the transaction table looked in regards to the sticky header and footer.

## What Changed

* [x] Wrapped the table in a container
* [x] Set percentage heights on the `.app__content` and `.table-container`

## Health Checks

These can be done by entering `rake` in the terminal

* [x] rspec
* [x] rubocop
* [x] audit

## Screenshots

<img width="1123" alt="Screenshot 2025-03-10 at 1 36 54 PM" src="https://github.com/user-attachments/assets/a579713d-4073-4289-96e1-3fb1735f9902" />
